### PR TITLE
Branch retire trigger

### DIFF
--- a/main/proc.sql
+++ b/main/proc.sql
@@ -110,9 +110,8 @@ WHERE
        participant_eid = NEW.eid
        AND datetime   >= CURRENT_DATE::TIMESTAMP
 ;
-
-RETURN NULL;
 END IF;
+RETURN NULL;
 END;
 $$ LANGUAGE plpgsql;
 CREATE OR REPLACE TRIGGER retire_employee

--- a/main/proc.sql
+++ b/main/proc.sql
@@ -17,10 +17,10 @@ END;
 $$ LANGUAGE plpgsql;
 CREATE OR REPLACE TRIGGER assign_fever_trig BEFORE
 INSERT
-    OR
+       OR
 UPDATE
 ON
-    health_declaration FOR EACH ROW EXECUTE PROCEDURE assign_fever()
+       health_declaration FOR EACH ROW EXECUTE PROCEDURE assign_fever()
 ;
 
 -- triggers that activate when an employee has a fever
@@ -31,28 +31,28 @@ BEGIN
 IF NEW.fever = 'true' THEN
 -- get close contacts (3 days or less)
 WITH get_close_contacts AS
-    (
-        SELECT
-            eid --returns close contacts
-        FROM
-            contact_tracing(NEW.eid)
-    )
+     (
+            SELECT
+                   eid --returns close contacts
+            FROM
+                   contact_tracing(NEW.eid)
+     )
 DELETE
 FROM
-    Sessions s
+       Sessions s
 WHERE
-    (
-        s.participant_eid = NEW.eid
-        OR s.booker_eid   = NEW.eid
-        OR s.participant_eid IN
-        (
-            select
-                eid
-            FROM
-                get_close_contacts
-        ) -- close contact of fever case
-    )
-    AND s.datetime >= NEW.date::TIMESTAMP
+       (
+              s.participant_eid = NEW.eid
+              OR s.booker_eid   = NEW.eid
+              OR s.participant_eid IN
+              (
+                     select
+                            eid
+                     FROM
+                            get_close_contacts
+              ) -- close contact of fever case
+       )
+       AND s.datetime >= NEW.date::TIMESTAMP
 ;
 
 END IF;
@@ -61,10 +61,10 @@ END;
 $$ LANGUAGE plpgsql;
 CREATE OR REPLACE TRIGGER check_fever AFTER
 INSERT
-    OR
+       OR
 UPDATE
 ON
-    health_declaration FOR EACH ROW EXECUTE PROCEDURE remove_future_meetings_on_fever()
+       health_declaration FOR EACH ROW EXECUTE PROCEDURE remove_future_meetings_on_fever()
 ;
 
 --Trigger to stop 2 managers from updating capacity of room in the same day
@@ -72,15 +72,15 @@ CREATE OR REPLACE FUNCTION updates_check() RETURNS TRIGGER AS $$
 begin
 if exists
 (
-    select
-        1
-    from
-        updates
-    where
-        floor              = new.floor
-        and room           = new.room
-        and date           = new.date
-        and approving_eid != new.approving_eid
+       select
+              1
+       from
+              updates
+       where
+              floor              = new.floor
+              and room           = new.room
+              and date           = new.date
+              and approving_eid != new.approving_eid
 )
 then
 raise notice 'capacity of room already updated today';
@@ -94,7 +94,34 @@ CREATE OR REPLACE TRIGGER updates_check_trigger
 BEFORE
 INSERT
 ON
-    updates FOR EACH ROW EXECUTE FUNCTION updates_check()
+       updates FOR EACH ROW EXECUTE FUNCTION updates_check()
+;
+
+-- trigger to remove retired employee  from  future  meetings
+CREATE OR REPLACE FUNCTION remove_future_meetings_on_retire()
+RETURNS TRIGGER AS
+$$
+BEGIN
+IF (NEW.resigned_date IS NOT NULL) THEN
+DELETE
+FROM
+       Sessions
+WHERE
+       participant_eid = NEW.eid
+       AND datetime   >= CURRENT_DATE::TIMESTAMP
+	   ;
+	   RETURN NULL;
+END IF;
+
+END;
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE TRIGGER retire_employee
+AFTER
+INSERT
+       OR
+UPDATE
+ON
+       employees FOR EACH ROW EXECUTE FUNCTION remove_future_meetings_on_retire()
 ;
 
 /**
@@ -103,19 +130,19 @@ ON
 CREATE OR REPLACE PROCEDURE add_department (IN did INTEGER, IN dname VARCHAR(50))
 AS $$
 INSERT INTO departments VALUES
-    (did
-      , dname
-    )
-    $$ LANGUAGE sql
+       (did
+            , dname
+       )
+       $$ LANGUAGE sql
 ;
 
 CREATE OR REPLACE PROCEDURE remove_department (IN target_did INTEGER)
 AS $$
 DELETE
 FROM
-    departments
+       departments
 WHERE
-    did = target_did $$ LANGUAGE sql
+       did = target_did $$ LANGUAGE sql
 ;
 
 CREATE OR REPLACE PROCEDURE add_room
@@ -128,18 +155,18 @@ room_name  varchar(50)
 AS
 $$
 INSERT INTO Meeting_Rooms
-    (rname
-      , floor
-      , room
-      , did
-    )
-    values
-    (room_name
-      , floor_num
-      , room_num
-      , did
-    )
-    $$ LANGUAGE SQL
+       (rname
+            , floor
+            , room
+            , did
+       )
+       values
+       (room_name
+            , floor_num
+            , room_num
+            , did
+       )
+       $$ LANGUAGE SQL
 ;
 
 -- Assume when room added no entry exists in [Updates]
@@ -154,31 +181,31 @@ AS $BODY$
 BEGIN
 IF EXISTS
 (
-    select
-        1
-    from
-        Manager
-    where
-        eid = manager_eid
+       select
+              1
+       from
+              Manager
+       where
+              eid = manager_eid
 )
 THEN
 INSERT INTO updates VALUES
-    (effective_date
-      , manager_eid
-      , capacity
-      , floornum
-      , roomnum
-    )
+       (effective_date
+            , manager_eid
+            , capacity
+            , floornum
+            , roomnum
+       )
 ON
-    CONFLICT
-    (date
-      , floor
-      , room
-      , approving_eid
-    )
-    DO
+       CONFLICT
+       (date
+            , floor
+            , room
+            , approving_eid
+       )
+       DO
 UPDATE
-SET new_cap = capacity
+SET    new_cap = capacity
 ;
 
 ELSE
@@ -186,22 +213,22 @@ RAISE EXCEPTION 'You are not a manager';
 END IF;
 DELETE
 FROM
-    sessions
+       sessions
 WHERE
-    floor    = floornum
-    AND room = roomnum
-    AND datetime IN
-    (
-        SELECT
-            datetime
-        FROM
-            session_pax
-        WHERE
-            floor        =floornum
-            AND room     =roomnum
-            AND datetime > effective_date::timestamp
-            AND pax      > capacity
-    )
+       floor    = floornum
+       AND room = roomnum
+       AND datetime IN
+       (
+              SELECT
+                     datetime
+              FROM
+                     session_pax
+              WHERE
+                     floor        =floornum
+                     AND room     =roomnum
+                     AND datetime > effective_date::timestamp
+                     AND pax      > capacity
+       )
 ;
 
 END
@@ -216,18 +243,18 @@ IN ename     VARCHAR(50)
 AS
 $$
 INSERT INTO employees
-    ( ename
-      , hp_contact
-      , kind
-      , did
-    )
-    VALUES
-    ( ename
-      , hp_contact
-      , kind
-      , did
-    )
-    $$ LANGUAGE SQL
+       ( ename
+            , hp_contact
+            , kind
+            , did
+       )
+       VALUES
+       ( ename
+            , hp_contact
+            , kind
+            , did
+       )
+       $$ LANGUAGE SQL
 ;
 
 CREATE OR REPLACE PROCEDURE remove_employee
@@ -238,10 +265,10 @@ IN eid          INTEGER
 AS
 $$
 UPDATE
-    employees
-SET resigned_date = $2
+       employees
+SET    resigned_date = $2
 WHERE
-    eid = $1
+       eid = $1
 ;
 
 $$ LANGUAGE SQL;
@@ -256,29 +283,32 @@ end_datetime   TIMESTAMP := (CAST(date AS TEXT) || ' ' || end_hour || ':00:00'):
 BEGIN
 IF EXISTS
 (
-    SELECT
-        1
-    FROM
-        Manager m, Employees e, Sessions s, Meeting_rooms r
-    WHERE
-        m.eid = approver_eid --is a manager
-        --check whether manager's did same as room's did
-        AND e.eid       = approver_eid
-        AND e.did       = r.did
-        AND s.floor     = r.floor
-        AND s.room      = r.room
-        AND s.datetime >= start_datetime
-        AND s.datetime  < end_datetime
+       SELECT
+              1
+       FROM
+              Manager       m
+            , Employees     e
+            , Sessions      s
+            , Meeting_rooms r
+       WHERE
+              m.eid = approver_eid --is a manager
+              --check whether manager's did same as room's did
+              AND e.eid       = approver_eid
+              AND e.did       = r.did
+              AND s.floor     = r.floor
+              AND s.room      = r.room
+              AND s.datetime >= start_datetime
+              AND s.datetime  < end_datetime
 )
 THEN
 UPDATE
-    Sessions
-SET approving_manager_eid = approver_eid
+       Sessions
+SET    approving_manager_eid = approver_eid
 WHERE
-    floor         = floor_no
-    AND room      = room_no
-    AND datetime >= start_datetime
-    AND datetime  < end_datetime
+       floor         = floor_no
+       AND room      = room_no
+       AND datetime >= start_datetime
+       AND datetime  < end_datetime
 ;
 
 ELSE
@@ -294,29 +324,29 @@ end_datetime   TIMESTAMP := (CAST(date AS TEXT) || ' ' || end_hour || ':00:00'):
 BEGIN
 IF EXISTS
 (
-    SELECT
-        1
-    FROM
-        Sessions
-    WHERE
-        approving_manager_eid ISNULL --meeting not approved yet
-        --check whether eid is participating in the specified meeting
-        AND participant_eid = leaver_eid
-        AND floor           = floor_no
-        AND room            = room_no
-        AND datetime       >= start_datetime
-        AND datetime        < end_datetime
+       SELECT
+              1
+       FROM
+              Sessions
+       WHERE
+              approving_manager_eid ISNULL --meeting not approved yet
+              --check whether eid is participating in the specified meeting
+              AND participant_eid = leaver_eid
+              AND floor           = floor_no
+              AND room            = room_no
+              AND datetime       >= start_datetime
+              AND datetime        < end_datetime
 )
 THEN
 DELETE
 FROM
-    Sessions
+       Sessions
 WHERE
-    participant_eid = leaver_eid
-    AND floor       = floor_no
-    AND room        = room_no
-    AND datetime   >= start_datetime
-    AND datetime    < end_datetime
+       participant_eid = leaver_eid
+       AND floor       = floor_no
+       AND room        = room_no
+       AND datetime   >= start_datetime
+       AND datetime    < end_datetime
 ;
 
 END IF;
@@ -333,48 +363,49 @@ increment_datetime TIMESTAMP   := start_datetime;
 BEGIN
 IF EXISTS
 (
-    SELECT
-        1
-    FROM
-        Sessions s, Employees e
-        --check whether meeting is joinable
-    WHERE
-        s.approving_manager_eid ISNULL
-        AND s.datetime >= start_datetime
-        AND s.datetime  < end_datetime
-        --check whether eid has resigned
-        AND e.eid = joiner_eid
-        AND e.resigned_date ISNULL
+       SELECT
+              1
+       FROM
+              Sessions  s
+            , Employees e
+              --check whether meeting is joinable
+       WHERE
+              s.approving_manager_eid ISNULL
+              AND s.datetime >= start_datetime
+              AND s.datetime  < end_datetime
+              --check whether eid has resigned
+              AND e.eid = joiner_eid
+              AND e.resigned_date ISNULL
 )
 -- check fever
 AND
 (
     EXISTS
     (
-        SELECT
-            1
-        FROM
-            Health_Declaration hd
-        WHERE
-            (
-                hd.eid       = $6
-                AND hd.date  = current_date
-                AND hd.fever = false
-            )
+           SELECT
+                  1
+           FROM
+                  Health_Declaration hd
+           WHERE
+                  (
+                         hd.eid       = $6
+                         AND hd.date  = current_date
+                         AND hd.fever = false
+                  )
     )
     OR
     (
         NOT EXISTS
         (
-            SELECT
-                1
-            FROM
-                Health_Declaration hd
-            WHERE
-                (
-                    hd.eid      = $6
-                    AND hd.date = current_date
-                )
+               SELECT
+                      1
+               FROM
+                      Health_Declaration hd
+               WHERE
+                      (
+                             hd.eid      = $6
+                             AND hd.date = current_date
+                      )
         )
     )
 )
@@ -384,41 +415,41 @@ LOOP
 EXIT WHEN increment_datetime = end_datetime;
 booker_eid_var :=
 (
-    SELECT
-        booker_eid
-    FROM
-        Sessions
-    WHERE
-        floor         = floor_no
-        AND room      = room_no
-        AND datetime >= start_datetime
-        AND datetime  < end_datetime
-    LIMIT 1
+       SELECT
+              booker_eid
+       FROM
+              Sessions
+       WHERE
+              floor         = floor_no
+              AND room      = room_no
+              AND datetime >= start_datetime
+              AND datetime  < end_datetime
+       LIMIT  1
 )
 ;
 rname_var :=
 (
-    SELECT
-        rname
-    FROM
-        Sessions
-    WHERE
-        floor         = floor_no
-        AND room      = room_no
-        AND datetime >= start_datetime
-        AND datetime  < end_datetime
-    LIMIT 1
+       SELECT
+              rname
+       FROM
+              Sessions
+       WHERE
+              floor         = floor_no
+              AND room      = room_no
+              AND datetime >= start_datetime
+              AND datetime  < end_datetime
+       LIMIT  1
 )
 ;
 INSERT INTO Sessions VALUES
-    (joiner_eid
-      , NULL
-      , booker_eid_var
-      , floor_no
-      , room_no
-      , increment_datetime
-      , rname_var
-    )
+       (joiner_eid
+            , NULL
+            , booker_eid_var
+            , floor_no
+            , room_no
+            , increment_datetime
+            , rname_var
+       )
 ;
 
 increment_datetime := increment_datetime + INTERVAL '1 HOUR';
@@ -428,15 +459,13 @@ RAISE EXCEPTION 'Meeting approved already/Invalid employee entered/ Employee has
 END IF;
 END
 $$ LANGUAGE plpgsql;
-
-
 CREATE OR REPLACE PROCEDURE public.book_room(
-    IN floornum integer,
-    IN roomnum integer,
-    IN bdate date,
-    IN start_hr integer,
-    IN end_hr integer,
-    IN beid integer)
+IN floornum integer,
+IN roomnum  integer,
+IN bdate    date,
+IN start_hr integer,
+IN end_hr   integer,
+IN beid     integer)
 LANGUAGE 'plpgsql'
 AS $BODY$
 DECLARE
@@ -448,13 +477,18 @@ bookingDatetime timestamp;
 isBooked        boolean := false;
 resignDate      date;
 BEGIN
-select resigned_date into resignDate
-from employees
-where eid = beid;
+select
+       resigned_date
+into
+       resignDate
+from
+       employees
+where
+       eid = beid
+;
 
 IF (resignDate IS NOT NULL) THEN
-    RAISE EXCEPTION 'eid % is resigned',beid;
-
+RAISE EXCEPTION 'eid % is resigned',beid;
 ELSIF NOT EXISTS
 (
        select
@@ -474,26 +508,25 @@ ELSIF NOT EXISTS
 THEN
 RAISE EXCEPTION 'eid % is not a senior or manager', beid;
 END IF;
-
 --If employee has fever today, reject booking. If employee didn't declare temp today, accept booking
 select
-    fever
+       fever
 into
-    hasFever
+       hasFever
 from
-    Health_Declaration
+       Health_Declaration
 where
        eid      = beid
        and date = CURRENT_DATE
 ;
+
 IF NOT FOUND THEN
-    hasFever:= false;
+hasFever:= false;
 END IF;
 --Employee declared temp but has fever today
 IF (hasFever IS TRUE) THEN
 RAISE EXCEPTION 'You have fever today, no booking allowed';
 END IF;
-
 --Check if room is booked
 bookingTime     := make_time(start_hr,0,0);
 bookingDatetime := bdate + bookingTime;
@@ -516,7 +549,6 @@ n := n-1;
 END LOOP;
 IF (isBooked IS TRUE) THEN RAISE EXCEPTION 'Time slot unavailable';
 END IF;
-
 --All checks passed, book the slots
 LOOP
 exit when j = 0;
@@ -536,7 +568,15 @@ INSERT INTO Sessions
             , floornum
             , roomnum
             , bookingDatetime + make_interval(hours => (j-1))
-            , (select rname from meeting_rooms where floor = floornum and room = roomnum)
+            , (
+                     select
+                            rname
+                     from
+                            meeting_rooms
+                     where
+                            floor    = floornum
+                            and room = roomnum
+              )
        )
 ;
 
@@ -544,8 +584,6 @@ j := j-1;
 END LOOP;
 END;
 $BODY$;
-
-
 CREATE OR REPLACE PROCEDURE unbook_room(
 IN floor_in integer,
 IN room_in  integer,
@@ -566,15 +604,15 @@ LOOP
 EXIT WHEN n=0;
 IF NOT EXISTS
 (
-    select
-        1
-    from
-        Sessions
-    where
-        floor          = floor_in
-        and room       = room_in
-        and datetime   = booking_datetime + make_interval(hours => (n-1))
-        and booker_eid = beid
+       select
+              1
+       from
+              Sessions
+       where
+              floor          = floor_in
+              and room       = room_in
+              and datetime   = booking_datetime + make_interval(hours => (n-1))
+              and booker_eid = beid
 )
 THEN bcheck := false;
 END IF;
@@ -586,12 +624,12 @@ LOOP
 EXIT WHEN j=0;
 DELETE
 FROM
-    Sessions
+       Sessions
 WHERE
-    floor          = floor_in
-    and room       = room_in
-    and datetime   = booking_datetime + make_interval(hours => (j-1))
-    and booker_eid = beid
+       floor          = floor_in
+       and room       = room_in
+       and datetime   = booking_datetime + make_interval(hours => (j-1))
+       and booker_eid = beid
 ;
 
 j := j-1;
@@ -605,73 +643,88 @@ end_datetime   timestamp := meeting_date + make_time(end_hr,0,0);
 begin
 RETURN QUERY
 WITH rooms_CTE AS
-    (
-        select *
-        from
-            updates
-            join
-                meeting_rooms
-        USING (floor, room)
-        where
-            new_cap >= min_cap
-            --rooms that are already booked for the input date and duration
-    )
-  , conflicting_sessions_CTE AS
-    (
-        select
-            floor, room
-        from
-            sessions
-        where
-            participant_eid = booker_eid
-            and datetime   >= start_datetime
-            and datetime    < end_datetime
-            --rooms that meet min capacity, which takes capacity from the entry with latest date in updates
-    )
-  , cleaned_rooms_CTE AS
-    (
-        select
-            r1.floor, r1.room, r1.new_cap, r1.did
-        from
-            rooms_CTE r1
-            join
-                (
-                    select
-                        floor, room, max(date) as maxdate
-                    from
-                        rooms_CTE
-                    group by
-                        (floor, room)
-                )
-                r2
-                on
-                    r1.floor   =r2.floor
-                    and r1.room=r2.room
-                    and r1.date=r2.maxdate
-        order by
-            (r1.floor, r1.room)
-    )
+     (
+            select *
+            from
+                   updates
+                   join
+                          meeting_rooms
+            USING  (floor
+                 , room)
+            where
+                   new_cap >= min_cap
+                   --rooms that are already booked for the input date and duration
+     )
+   , conflicting_sessions_CTE AS
+     (
+            select
+                   floor
+                 , room
+            from
+                   sessions
+            where
+                   participant_eid = booker_eid
+                   and datetime   >= start_datetime
+                   and datetime    < end_datetime
+                   --rooms that meet min capacity, which takes capacity from the entry with latest date in updates
+     )
+   , cleaned_rooms_CTE AS
+     (
+            select
+                   r1.floor
+                 , r1.room
+                 , r1.new_cap
+                 , r1.did
+            from
+                   rooms_CTE r1
+                   join
+                          (
+                                 select
+                                        floor
+                                      , room
+                                      , max(date) as maxdate
+                                 from
+                                        rooms_CTE
+                                 group by
+                                        (floor
+                                      , room)
+                          )
+                          r2
+                          on
+                                 r1.floor   =r2.floor
+                                 and r1.room=r2.room
+                                 and r1.date=r2.maxdate
+            order by
+                   (r1.floor
+                 , r1.room)
+     )
 select *
 from
-    (
-        select
-            floor, room, did, new_cap
-        from
-            cleaned_rooms_CTE
-        except
-        select
-            cr.floor, cr.room, cr.did, cr.new_cap
-        from
-            cleaned_rooms_CTE cr
-            join
-                conflicting_sessions_CTE s
-                on
-                    cr.floor   =s.floor
-                    and cr.room=s.room
-    )
-    ans
+       (
+              select
+                     floor
+                   , room
+                   , did
+                   , new_cap
+              from
+                     cleaned_rooms_CTE
+              except
+              select
+                     cr.floor
+                   , cr.room
+                   , cr.did
+                   , cr.new_cap
+              from
+                     cleaned_rooms_CTE cr
+                     join
+                            conflicting_sessions_CTE s
+                            on
+                                   cr.floor   =s.floor
+                                   and cr.room=s.room
+       )
+       ans
 order by
-    (ans.new_cap) asc
+       (ans.new_cap) asc
 ;
 
 end;
@@ -689,26 +742,26 @@ AS
 $$
 BEGIN
 INSERT INTO Health_Declaration
-    ( eid
-      , date
-      , temp
-    )
-    VALUES
-    ( $1
-      , $2
-      , $3
-    )
+       ( eid
+            , date
+            , temp
+       )
+       VALUES
+       ( $1
+            , $2
+            , $3
+       )
 ON
-    CONFLICT
-    (eid
-      , date
-    )
-    DO
+       CONFLICT
+       (eid
+            , date
+       )
+       DO
 UPDATE
-SET temp = $3
+SET    temp = $3
 WHERE
-    Health_Declaration.eid      = $1
-    AND Health_Declaration.date = $2
+       Health_Declaration.eid      = $1
+       AND Health_Declaration.date = $2
 ;
 
 END;
@@ -723,26 +776,30 @@ BEGIN
 RETURN QUERY
 --get all meetings that fever guy joined, more specifically the time, booker_eid, room and floor
 WITH get_meetings AS
-    (
-        SELECT
-            s.booker_eid , s.datetime , s.room , s.floor
-        FROM
-            Sessions s
-        WHERE
-            s.participant_eid = $1
-    )
+     (
+            SELECT
+                   s.booker_eid
+                 , s.datetime
+                 , s.room
+                 , s.floor
+            FROM
+                   Sessions s
+            WHERE
+                   s.participant_eid = $1
+     )
 --get participants list from PAST 3 meeting dates
 -- simply consider range of 3 days --> current_timestamp - interval '3 days' to now.
 SELECT DISTINCT
-    s.participant_eid
+       s.participant_eid
 FROM
-    get_meetings gm , Sessions s
+       get_meetings gm
+     , Sessions     s
 WHERE
-    gm.datetime           >= curr_date - INTERVAL '3 days'
-    AND s.booker_eid       = gm.booker_eid
-    AND s.participant_eid <> $1 -- dont want fever fella
-    AND gm.room            = s.room
-    AND gm.floor           = s.floor
+       gm.datetime           >= curr_date - INTERVAL '3 days'
+       AND s.booker_eid       = gm.booker_eid
+       AND s.participant_eid <> $1 -- dont want fever fella
+       AND gm.room            = s.room
+       AND gm.floor           = s.floor
 ;
 
 END;
@@ -755,40 +812,49 @@ RETURNS TABLE (floor_no                                    INTEGER, room_no INTE
 BEGIN
 IF NOT EXISTS
 (
-    SELECT
-        1
-    FROM
-        Manager m
-    WHERE
-        m.eid = manager_eid
+       SELECT
+              1
+       FROM
+              Manager m
+       WHERE
+              m.eid = manager_eid
 )
 THEN RETURN QUERY
 (
-    SELECT
-        floor, room, datetime::DATE, datetime::TIMESTAMP
-      , participant_eid
-    FROM
-        Sessions
-    WHERE
-        booker_eid ISNULL
+       SELECT
+              floor
+            , room
+            , datetime::DATE
+            , datetime::TIMESTAMP
+            , participant_eid
+       FROM
+              Sessions
+       WHERE
+              booker_eid ISNULL
 )
 ;
 ELSE RETURN QUERY
 (
-    SELECT
-        s.floor, s.room, s.datetime::DATE, s.datetime::TIMESTAMP
-      , s.participant_eid
-    FROM
-        Sessions s, Meeting_rooms r, Employees e
-    WHERE
-        s.approving_manager_eid ISNULL
-        AND datetime::DATE >= start_date
-        AND e.eid           = manager_eid --link manager to employees
-        AND s.floor         = r.floor     --link sessions to meeting_rooms
-        AND s.room          = r.room      --link sessions to meeting_rooms
-        AND e.did           = r.did       --manager's did same as room's did
-    ORDER BY
-        datetime::DATE, datetime::TIMESTAMP ASC
+       SELECT
+              s.floor
+            , s.room
+            , s.datetime::DATE
+            , s.datetime::TIMESTAMP
+            , s.participant_eid
+       FROM
+              Sessions      s
+            , Meeting_rooms r
+            , Employees     e
+       WHERE
+              s.approving_manager_eid ISNULL
+              AND datetime::DATE >= start_date
+              AND e.eid           = manager_eid --link manager to employees
+              AND s.floor         = r.floor     --link sessions to meeting_rooms
+              AND s.room          = r.room      --link sessions to meeting_rooms
+              AND e.did           = r.did       --manager's did same as room's did
+       ORDER BY
+              datetime::DATE
+            , datetime::TIMESTAMP ASC
 )
 ;
 END IF;
@@ -803,68 +869,76 @@ END IF;
 RETURN QUERY
 -- generate all possible dates
 WITH gen_date AS
-    (
-        SELECT
-            date::date
-        FROM
-            generate_series($1, $2, '1 day'::interval) date
-    )
-  ,
-     -- generate all possible eid | dates combination
-    eid_date AS
-    (
-        SELECT
-            e.eid , gd.date
-        FROM
-            Employees e , gen_date gd
-    )
-  ,
-     -- get all eid and dates not declared
-    eid_not_declared_on AS
-    (
-        SELECT
-            ed.eid , ed.date
-        FROM
-            eid_date ed
-        EXCEPT
-        SELECT
-            hd.eid , hd.date
-        FROM
-            Health_Declaration hd
-    )
+     (
+            SELECT
+                   date::date
+            FROM
+                   generate_series($1, $2, '1 day'::interval) date
+     )
+   ,
+      -- generate all possible eid | dates combination
+     eid_date AS
+     (
+            SELECT
+                   e.eid
+                 , gd.date
+            FROM
+                   Employees e
+                 , gen_date  gd
+     )
+   ,
+      -- get all eid and dates not declared
+     eid_not_declared_on AS
+     (
+            SELECT
+                   ed.eid
+                 , ed.date
+            FROM
+                   eid_date ed
+            EXCEPT
+            SELECT
+                   hd.eid
+                 , hd.date
+            FROM
+                   Health_Declaration hd
+     )
 SELECT
-    endo.eid , COUNT(endo.date) nDays
+       endo.eid
+     , COUNT(endo.date) nDays
 FROM
-    eid_not_declared_on endo
+       eid_not_declared_on endo
 GROUP BY
-    endo.eid
+       endo.eid
 ORDER BY
-    COUNT(endo.date) DESC
+       COUNT(endo.date) DESC
 ;
 
 END;
 $$ LANGUAGE plpgsql;
-
-
 CREATE OR REPLACE FUNCTION view_booking_report (eid int, start_date date)
 RETURNS TABLE(floornum                              int, roomnum int, booking_datetime timestamp, is_approved boolean) AS $$
 DECLARE
 BEGIN
 RETURN QUERY
 SELECT DISTINCT
-    s.floor , s.room , s.datetime , CASE
-        WHEN s.approving_manager_eid IS NULL
-            THEN false
-            ELSE true
-    END AS is_approved
+       s.floor
+     , s.room
+     , s.datetime
+     , CASE
+              WHEN s.approving_manager_eid IS NULL
+                     THEN false
+                     ELSE true
+       END AS is_approved
 FROM
-    Sessions s, Meeting_Rooms mr, Employees e
+       Sessions      s
+     , Meeting_Rooms mr
+     , Employees     e
 WHERE
-    e.eid           = $1
-    AND e.did       = mr.did --same department
-    AND s.datetime >= start_date::timestamp
+       e.eid           = $1
+       AND e.did       = mr.did --same department
+       AND s.datetime >= start_date::timestamp
 ORDER BY
-    datetime ASC
+       datetime ASC
 ;
 
 END;
@@ -908,7 +982,7 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE TRIGGER assign_email_add BEFORE
 INSERT
 ON
-    employees FOR EACH ROW EXECUTE FUNCTION assign_email()
+       employees FOR EACH ROW EXECUTE FUNCTION assign_email()
 ;
 
 --Routine to add sessions
@@ -925,73 +999,78 @@ $$
 BEGIN
 RETURN QUERY
 WITH rand_id AS
-    (
-        SELECT
-            eid participant_id
-        FROM
-            employees
-        ORDER BY
-            random()
-        LIMIT n
-    )
-  , rand_man_id AS
-    (
-        SELECT
-            eid man_id
-        FROM
-            manager
-        ORDER BY
-            random()
-        LIMIT n
-    )
-  , rand_book_id AS
-    (
-        SELECT
-            js.eid booker_id
-        FROM
-            (
-                SELECT
-                    eid
-                FROM
-                    Junior
-                UNION
-                SELECT
-                    eid
-                FROM
-                    Senior
-            )
-            js
-        ORDER BY
-            random()
-        LIMIT n
-    )
-  , rand_room AS
-    (
-        SELECT
-            rname , floor , room
-        FROM
-            meeting_rooms
-        OFFSET random() *
-            (
-                SELECT
-                    count(*)
-                FROM
-                    meeting_rooms
-            )
-        LIMIT n
-    )
-  , get_timestamp AS
-    (
-        SELECT DISTINCT
-            generate_series( (current_date)::timestamp, (current_date + interval '1 MONTH')::timestamp, interval '1 hour' ) timestamps
-        LIMIT n
-    )
+     (
+            SELECT
+                   eid participant_id
+            FROM
+                   employees
+            ORDER BY
+                   random()
+            LIMIT  n
+     )
+   , rand_man_id AS
+     (
+            SELECT
+                   eid man_id
+            FROM
+                   manager
+            ORDER BY
+                   random()
+            LIMIT  n
+     )
+   , rand_book_id AS
+     (
+            SELECT
+                   js.eid booker_id
+            FROM
+                   (
+                          SELECT
+                                 eid
+                          FROM
+                                 Junior
+                          UNION
+                          SELECT
+                                 eid
+                          FROM
+                                 Senior
+                   )
+                   js
+            ORDER BY
+                   random()
+            LIMIT  n
+     )
+   , rand_room AS
+     (
+            SELECT
+                   rname
+                 , floor
+                 , room
+            FROM
+                   meeting_rooms
+            OFFSET random() *
+                   (
+                          SELECT
+                                 count(*)
+                          FROM
+                                 meeting_rooms
+                   )
+            LIMIT  n
+     )
+   , get_timestamp AS
+     (
+            SELECT DISTINCT
+                   generate_series( (current_date)::timestamp, (current_date + interval '1 MONTH')::timestamp, interval '1 hour' ) timestamps
+            LIMIT  n
+     )
 SELECT DISTINCT
-    *
+       *
 FROM
-    rand_id , rand_man_id , rand_book_id , rand_room
-  , get_timestamp
-LIMIT n
+       rand_id
+     , rand_man_id
+     , rand_book_id
+     , rand_room
+     , get_timestamp
+LIMIT  n
 ;
 
 END;
@@ -1002,23 +1081,23 @@ AS
 $$
 BEGIN
 INSERT INTO Sessions
-    (participant_eid
-      , approving_manager_eid
-      , booker_eid
-      , room
-      , floor
-      , datetime
-      , rname
-    )
-    VALUES
-    ($1
-      , $2
-      , $3
-      , $4
-      , $5
-      , $6
-      , $7
-    )
+       (participant_eid
+            , approving_manager_eid
+            , booker_eid
+            , room
+            , floor
+            , datetime
+            , rname
+       )
+       VALUES
+       ($1
+            , $2
+            , $3
+            , $4
+            , $5
+            , $6
+            , $7
+       )
 ;
 
 END;
@@ -1029,22 +1108,27 @@ AS
 $$
 BEGIN
 INSERT INTO Sessions
-    (participant_eid
-      , approving_manager_eid
-      , booker_eid
-      , room
-      , floor
-      , datetime
-      , rname
-    )
+       (participant_eid
+            , approving_manager_eid
+            , booker_eid
+            , room
+            , floor
+            , datetime
+            , rname
+       )
 SELECT
-    participant_id , man_id          , booker_id , room_no
-  , floor_no       , time_of_booking , room_name
+       participant_id
+     , man_id
+     , booker_id
+     , room_no
+     , floor_no
+     , time_of_booking
+     , room_name
 FROM
-    generate_random_sessions_table(how_many_to_insert)
+       generate_random_sessions_table(how_many_to_insert)
 ON
-    CONFLICT(participant_eid, datetime, booker_eid, room, floor) -- primary key
-    DO NOTHING                                                   -- strictly  for dummy data;
+       CONFLICT(participant_eid, datetime, booker_eid, room, floor) -- primary key
+       DO NOTHING                                                   -- strictly  for dummy data;
 END
 ;
 
@@ -1056,14 +1140,16 @@ DECLARE startTimestamp TIMESTAMP := $1::TIMESTAMP; -- casts date to timestamp
 BEGIN
 RETURN QUERY
 SELECT
-    s.floor , s.room , s.datetime
+       s.floor
+     , s.room
+     , s.datetime
 FROM
-    Sessions s
+       Sessions s
 WHERE
-    s.datetime           >= startTimestamp
-    AND s.participant_eid = $2
+       s.datetime           >= startTimestamp
+       AND s.participant_eid = $2
 ORDER BY
-    s.datetime ASC
+       s.datetime ASC
 ;
 
 END;
@@ -1073,16 +1159,17 @@ RETURNS TABLE(procedure name) AS $$
 BEGIN
 RETURN QUERY
 SELECT
-    p.proname as procedure
+       p.proname as procedure
 FROM
-    pg_proc p
-    join
-        pg_namespace n
-        on
-            p.pronamespace = n.oid
+       pg_proc p
+       join
+              pg_namespace n
+              on
+                     p.pronamespace = n.oid
 WHERE
-    n.nspname not in ('pg_catalog', 'information_schema')
-    and p.prokind = 'p'
+       n.nspname not in ('pg_catalog'
+                       , 'information_schema')
+       and p.prokind = 'p'
 ;
 
 END;
@@ -1096,5 +1183,5 @@ END; $$ LANGUAGE plpgsql;
 CREATE TRIGGER stop_delete_statement BEFORE
 DELETE
 ON
-    Employees FOR EACH STATEMENT EXECUTE FUNCTION stop_delete_employee()
+       Employees FOR EACH STATEMENT EXECUTE FUNCTION stop_delete_employee()
 ;

--- a/main/proc.sql
+++ b/main/proc.sql
@@ -294,7 +294,7 @@ IF EXISTS
               --check whether manager's did same as room's did
               AND e.eid       = approver_eid
               AND e.did       = r.did
-			  AND e.resigned_date IS NOT NULL -- check not resigned
+			  AND e.resigned_date IS NULL -- check not resigned
               AND s.floor     = r.floor
               AND s.room      = r.room
               AND s.datetime >= start_datetime
@@ -1128,7 +1128,8 @@ FROM
        generate_random_sessions_table(how_many_to_insert)
 ON
        CONFLICT(participant_eid, datetime, booker_eid, room, floor) -- primary key
-       DO NOTHING                                                   -- strictly  for dummy data;
+       DO NOTHING   ;       
+	   -- strictly  for dummy data;
 END
 ;
 
@@ -1185,3 +1186,40 @@ DELETE
 ON
        Employees FOR EACH STATEMENT EXECUTE FUNCTION stop_delete_employee()
 ;
+
+-- drop all procedures, useful for importing a fresh database
+-- reference: https://dba.stackexchange.com/questions/122742/how-to-drop-all-of-my-functions-in-postgresql
+CREATE OR REPLACE PROCEDURE drop_all_procedures() AS
+$$
+BEGIN
+DO
+$do$
+DECLARE
+   _sql text;
+BEGIN
+   SELECT INTO _sql
+          string_agg(format('DROP %s %s;'
+                          , CASE prokind
+                              WHEN 'f' THEN 'FUNCTION'
+                              WHEN 'a' THEN 'AGGREGATE'
+                              WHEN 'p' THEN 'PROCEDURE'
+                              WHEN 'w' THEN 'FUNCTION'  -- window function (rarely applicable)
+                              -- ELSE NULL              -- not possible in pg 11
+                            END
+                          , oid::regprocedure)
+                   , E'\n')
+   FROM   pg_proc
+   WHERE  pronamespace = 'public'::regnamespace  -- schema name here!
+   -- AND    prokind = ANY ('{f,a,p,w}')         -- optionally filter kinds
+   ;
+
+   IF _sql IS NOT NULL THEN
+      RAISE NOTICE '%', _sql;  -- debug / check first
+      -- EXECUTE _sql;         -- uncomment payload once you are sure
+   ELSE 
+      RAISE NOTICE 'No fuctions found in schema %', quote_ident(_schema);
+   END IF;
+END
+$do$;
+END;
+$$ LANGUAGE plpgsql;

--- a/main/proc.sql
+++ b/main/proc.sql
@@ -295,6 +295,7 @@ IF EXISTS
               --check whether manager's did same as room's did
               AND e.eid       = approver_eid
               AND e.did       = r.did
+			  AND e.resigned_date IS NOT NULL -- check not resigned
               AND s.floor     = r.floor
               AND s.room      = r.room
               AND s.datetime >= start_datetime
@@ -312,7 +313,7 @@ WHERE
 ;
 
 ELSE
-RAISE EXCEPTION 'Invalid manager entered / Meeting Not Found!';
+RAISE EXCEPTION 'Employee is not a manager/ Manager is not in same department as meeting room/ Employee is resigned / Approver has fever / Meeting Not Found!';
 END IF;
 END
 $$ LANGUAGE plpgsql;

--- a/main/proc.sql
+++ b/main/proc.sql
@@ -109,10 +109,10 @@ FROM
 WHERE
        participant_eid = NEW.eid
        AND datetime   >= CURRENT_DATE::TIMESTAMP
-	   ;
-	   RETURN NULL;
-END IF;
+;
 
+RETURN NULL;
+END IF;
 END;
 $$ LANGUAGE plpgsql;
 CREATE OR REPLACE TRIGGER retire_employee


### PR DESCRIPTION
Fixes #50
Now removes future meetings of a retired employee
Stops retired employee  from approving  meeting
Add procedure to clean all current procedures (drop_all_procedures())